### PR TITLE
feat: Extend ARM Support to `arm64` Systems

### DIFF
--- a/noirup
+++ b/noirup
@@ -86,9 +86,15 @@ main() {
         ;;
     esac
 
-    # We currently only provide binaries targetting x64_64 architectures.
-
+    # Fetch system's architecture.
     ARCHITECTURE="$(uname -m)"
+
+    # Align ARM naming for release fetching.
+    if [ "${ARCHITECTURE}" = "arm64" ]; then
+      ARCHITECTURE="aarch64" # Align release naming.
+    fi
+
+    # Reject unsupported architectures.
     if [ "${ARCHITECTURE}" != "x86_64" ] && [ "${ARCHITECTURE}" != "aarch64" ]; then
       err "unsupported architecure: $ARCHITECTURE-$PLATFORM"
     fi  
@@ -102,11 +108,6 @@ main() {
     #   else
     #     ARCHITECTURE="amd64" # Intel.
     #   fi
-    # elif [ "${ARCHITECTURE}" = "arm64" ] ||[ "${ARCHITECTURE}" = "aarch64" ] ; then
-    #   ARCHITECTURE="arm64" # Arm.
-    # else
-    #   ARCHITECTURE="amd64" # Amd.
-    # fi
 
     # Compute the URL of the release tarball in the Noir repository.
     RELEASE_URL="https://github.com/${NOIRUP_REPO}/releases/download/${NOIRUP_TAG}"

--- a/noirup
+++ b/noirup
@@ -97,17 +97,9 @@ main() {
     # Reject unsupported architectures.
     if [ "${ARCHITECTURE}" != "x86_64" ] && [ "${ARCHITECTURE}" != "aarch64" ]; then
       err "unsupported architecure: $ARCHITECTURE-$PLATFORM"
-    fi  
+    fi
 
     say "installing nargo (version ${NOIRUP_VERSION}, tag ${NOIRUP_TAG})"
-
-    # if [ "${ARCHITECTURE}" = "x86_64" ]; then
-    #   # Redirect stderr to /dev/null to avoid printing errors if non Rosetta.
-    #   if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
-    #     ARCHITECTURE="arm64" # Rosetta.
-    #   else
-    #     ARCHITECTURE="amd64" # Intel.
-    #   fi
 
     # Compute the URL of the release tarball in the Noir repository.
     RELEASE_URL="https://github.com/${NOIRUP_REPO}/releases/download/${NOIRUP_TAG}"


### PR DESCRIPTION
# Related issue(s)

Resolves https://github.com/noir-lang/noirup/issues/3.

This PR is extended from PR https://github.com/noir-lang/noirup/pull/2. Best to close that first before this.

# Description

## Summary of changes

Add support for `arm64` architecture by treating it as `aarch64`.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
