### PR TITLE
Fix macOS installation

### DIFF
--- a/noirup
+++ b/noirup
@@ -119,7 +119,7 @@ main() {
     # Replace existing std_lib with copy from new installation.
     ensure rm -rf "$CONFIG_DIR/noir-lang/std"
     say "installing noir-lang/std lib to '$CONFIG_DIR'"
-    ensure mv "$NARGO_BIN_DIR/noir-lang" $CONFIG_DIR
+    ensure mv "$NARGO_BIN_DIR/noir-lang" "$CONFIG_DIR"
 
   else
     need_cmd cargo


### PR DESCRIPTION
# Related issue(s)

Resolves https://github.com/noir-lang/noirup/issues/6

# Description

## Summary of changes

Addresses an issue where the space between "Application" and "Support" isn't interpreted as part of the path. Original installation error:
```
mv: Support is not a directory
noirup: command failed: mv /Users/aztec/.nargo/bin/noir-lang /Users/aztec/Library/Application Support
```

## Dependency additions / changes

https://github.com/noir-lang/noirup/pull/2 also needs merging before the installation will work.

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.
