### PR TITLE
feat!: Install from latest release by default

### DIFF
--- a/noirup
+++ b/noirup
@@ -12,6 +12,7 @@ main() {
     case $1 in
       --)               shift; break;;
 
+      -n|--nightly)     shift; NOIRUP_NIGHTLY="1";;
       -r|--repo)        shift; NOIRUP_REPO=$1;;
       -b|--branch)      shift; NOIRUP_BRANCH=$1;;
       -v|--version)     shift; NOIRUP_VERSION=$1;;
@@ -61,16 +62,6 @@ main() {
 
   NOIRUP_REPO=${NOIRUP_REPO-noir-lang/noir}
   if [[ "$NOIRUP_REPO" == "noir-lang/noir" && -z "$NOIRUP_BRANCH" && -z "$NOIRUP_COMMIT" ]]; then
-    NOIRUP_VERSION=${NOIRUP_VERSION-nightly}
-    NOIRUP_TAG=$NOIRUP_VERSION
-
-    # Normalize versions (handle channels, versions without v prefix)
-    if [[ "$NOIRUP_VERSION" == [[:digit:]]* ]]; then
-      # Add v prefix
-      NOIRUP_VERSION="v${NOIRUP_VERSION}"
-      NOIRUP_TAG="${NOIRUP_VERSION}"
-    fi
-
     PLATFORM="$(uname -s)"
     case $PLATFORM in
       Linux)
@@ -99,10 +90,26 @@ main() {
       err "unsupported architecure: $ARCHITECTURE-$PLATFORM"
     fi
 
-    say "installing nargo (version ${NOIRUP_VERSION}, tag ${NOIRUP_TAG})"
-
     # Compute the URL of the release tarball in the Noir repository.
-    RELEASE_URL="https://github.com/${NOIRUP_REPO}/releases/download/${NOIRUP_TAG}"
+    if [ -z "$NOIRUP_NIGHTLY" ] && [ -z "$NOIRUP_VERSION" ]; then
+      say "installing nargo (latest stable)"
+
+      RELEASE_URL="https://github.com/${NOIRUP_REPO}/releases/latest/download"
+    else
+      NOIRUP_VERSION=${NOIRUP_VERSION-nightly}
+      NOIRUP_TAG=$NOIRUP_VERSION
+
+      # Normalize versions (handle channels, versions without v prefix)
+      if [[ "$NOIRUP_VERSION" == [[:digit:]]* ]]; then
+        # Add v prefix
+        NOIRUP_VERSION="v${NOIRUP_VERSION}"
+        NOIRUP_TAG="${NOIRUP_VERSION}"
+      fi
+
+      say "installing nargo (version ${NOIRUP_VERSION} with tag ${NOIRUP_TAG})"
+
+      RELEASE_URL="https://github.com/${NOIRUP_REPO}/releases/download/${NOIRUP_TAG}"
+    fi
     BIN_TARBALL_URL="${RELEASE_URL}/nargo-${ARCHITECTURE}-${PLATFORM}.tar.gz"
 
     # Download the binaries tarball and unpack it into the .nargo bin directory.


### PR DESCRIPTION
# Related issue(s)

N/A

# Description

Now that we have stable Noir & Nargo releases, we should switch the default noirup target to the latest stable. We can do this with the special `/owner/name/releases/latest/download/asset-name` URL. This PR updates the logic to install latest stable by default and adds a `--nightly` flag to install from nightly. I also updated the message output to be accurate with the change.

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
