### PR TITLE
feat(ci): Add release-please action to handle releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         id: release
         uses: google-github-actions/release-please-action@v3
         with:
+          token: ${{ secrets.NOIRUP_REPO_TOKEN }}
           release-type: simple
           package-name: noirup
           bump-minor-pre-major: true
@@ -32,6 +33,7 @@ jobs:
       - name: Upload files to release
         uses: svenstaro/upload-release-action@v2
         with:
+          repo_token: ${{ secrets.NOIRUP_REPO_TOKEN }}
           file: ./{noirup,install-windows}
           file_glob: true
           overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-please:
+    name: Create Release
+    outputs:
+      release-pr: ${{ steps.release.outputs.pr }}
+      tag-name: ${{ steps.release.outputs.tag_name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run release-please
+        id: release
+        uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: simple
+          package-name: noirup
+          bump-minor-pre-major: true
+          bump-patch-for-minor-pre-major: true
+          pull-request-title-pattern: "chore(noirup): Release ${version}"
+
+  upload-files:
+    name: Upload files to release
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.tag-name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload files to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: ./{noirup,install-windows}
+          file_glob: true
+          overwrite: true
+          tag: ${{ needs.release-please.outputs.tag-name }}
+

--- a/install
+++ b/install
@@ -6,7 +6,7 @@ echo Installing noirup...
 NARGO_HOME=${NARGO_HOME-"$HOME/.nargo"}
 NARGO_BIN_DIR="$NARGO_HOME/bin"
 
-BIN_URL="https://raw.githubusercontent.com/noir-lang/noirup/main/noirup"
+BIN_URL="https://github.com/noir-lang/noirup/releases/latest/download/noirup"
 BIN_PATH="$NARGO_BIN_DIR/noirup"
 
 # Create the .nargo bin directory and noirup binary if it doesn't exist.


### PR DESCRIPTION
# Related issue(s)

See: https://github.com/noir-lang/noirup/pull/11#discussion_r1101952650

# Description

## Summary of changes

This PR adds release-please which will create releases consisting of `noirup` and `install-windows`.

I've omitted `install` as this is more of a quickstart bootstrapping script rather than something that should be relied upon for stability. If someone needs to fix to a particular version of `noirup` in CI then they can pull in a particular version of the github action. 

As part of this change I've changed `install` to pull the latest release of noirup instead of the version on `main` so we'll need to cut a release after merging this PR (we could also split this off).

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
