### PR TITLE
fix: support installing nargo v0.3.0+

### DIFF
--- a/noirup
+++ b/noirup
@@ -116,11 +116,14 @@ main() {
     say "downloading latest nargo to '$NARGO_BIN_DIR'"
     ensure curl -# -L $BIN_TARBALL_URL | tar -xzC $NARGO_BIN_DIR
 
-    # Replace existing std_lib with copy from new installation.
+    # Prior to v0.3.0, Nargo and the std lib were distributed separated.
     ensure rm -rf "$CONFIG_DIR/noir-lang/std"
-    say "installing noir-lang/std lib to '$CONFIG_DIR'"
-    ensure mv "$NARGO_BIN_DIR/noir-lang" "$CONFIG_DIR"
-
+    if [ -d "$NARGO_BIN_DIR/noir-lang" ]; then
+      # Release tarball contains std lib so we're installing a version prior to v0.3.0.
+      # Move std lib to location expected by Nargo.
+      say "installing noir-lang/std lib to '$CONFIG_DIR'"
+      ensure mv "$NARGO_BIN_DIR/noir-lang" "$CONFIG_DIR"
+    fi
   else
     need_cmd cargo
     NOIRUP_BRANCH=${NOIRUP_BRANCH-master}


### PR DESCRIPTION
# Related issue(s)

Resolves #14 

# Description

## Summary of changes

We now only attempt to copy the standard library if it exists in the downloaded tarball. This works for nargo version both pre and post 0.3.0.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
