### PR TITLE
fix: update `install-windows` to not expect a separate stdlib

### DIFF
--- a/install-windows
+++ b/install-windows
@@ -28,8 +28,6 @@ if ($myWindowsPrincipal.IsInRole($adminRole))
     Invoke-RestMethod -Method Get -Uri $nargoUri -OutFile $tmp
     Write-Output "Expanding '$tmp' to '$nargoHomeBin'";
     Expand-Archive -Force -Path $tmp -DestinationPath $nargoHomeBin
-    Write-Output "Moving '$nargoHomeBin\noir-lang' to '$env:APPDATA\noir-lang'";
-    Move-Item -Force -Path "$nargoHomeBin\noir-lang" -Destination "$env:APPDATA\noir-lang"
 
     $Reg = "Registry::HKLM\System\CurrentControlSet\Control\Session Manager\Environment"
     $OldPath = (Get-ItemProperty -Path "$Reg" -Name PATH).Path


### PR DESCRIPTION
# Related issue(s)

Resolves #14 

# Description

## Summary of changes

`install-windows` only downloads the latests nightly release so we don't have to support downloading nargo 0.2.0 or lower. I've then removed the lines which copy across the std lib to the appdata folder.

I don't have windows so I can't test this however.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
