### PR TITLE
feat(action): cache `transcript00.dat` file to mitigate flakey downloader

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,12 @@ runs:
         toolchain: ${{inputs.toolchain}}
       shell: bash
 
+    - name: Cache Barretenberg transcript
+      uses: actions/cache@v3
+      with:
+        path: ~/noir_cache/ignition/transcript00.dat
+        key: noir_cache
+
     - name: Create `.nargo/bin` directory
       shell: bash
       run: |


### PR DESCRIPTION
Potential short term fix for the issue of macos not always being able to download the transcript file