### PR TITLE
chore(ci): add CI test for installing noirup on CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,42 @@ permissions:
 
 jobs:
   install:
-    name: Noir ${{matrix.toolchain}} on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
+    name: Noir ${{matrix.toolchain}} (CLI) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos]
+        toolchain: [stable, nightly, 0.1.0, 0.1.1, 0.2.0, 0.3.0]
+    timeout-minutes: 45
+    steps:
+      - name: Parse toolchain
+        id: parse
+        run: |
+          : parse toolchain version
+          if [[ $toolchain == "stable" ]]; then
+            : By default, noirup installs the latest stable version
+          elif [[ $toolchain == "nightly" ]]; then
+            echo "toolchain="--nightly"" >> $GITHUB_OUTPUT
+          else
+            echo "toolchain="--version $toolchain"" >> $GITHUB_OUTPUT
+          fi
+        env:
+          toolchain: ${{matrix.toolchain}}
+      
+      - name: Install noirup
+        run: |
+          curl -L $INSTALL_URL | bash
+          echo "${HOME}/.nargo/bin" >> $GITHUB_PATH
+        env:
+          INSTALL_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/install
+      - name: Install nargo with noirup
+        run: noirup ${{steps.parse.outputs.toolchain}} 
+      - name: Check nargo installation
+        run: nargo --version
+
+  install-action:
+    name: Noir ${{matrix.toolchain}} (GH action) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
     runs-on: ${{matrix.os}}-latest
     strategy:
       fail-fast: false

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,6 @@ runs:
       shell: bash
       run: |
         mkdir -p $HOME/.nargo/bin
-        chmod +x $HOME/.nargo/bin
         echo "${HOME}/.nargo/bin" >> $GITHUB_PATH
 
     - name: Run Noirup


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

We've got a test for installing nargo through the noirup gh action but not for the end user on the CLI.

This PR adds CI for this as well, essentially testing that `install` is working correctly. It's not a perfect reflection of how a user would install `noirup` due to github handles the path but it's good enough.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
