### PR TITLE
fix: update path to package containing nargo binary

### DIFF
--- a/noirup
+++ b/noirup
@@ -147,7 +147,7 @@ main() {
     fi
     # Build the repo and install it locally to the .nargo bin directory.
     # --root appends /bin to the directory it is given, so we pass NARGO_HOME.
-    RUSTFLAGS="-C target-cpu=native" ensure cargo install --path ./crates/nargo --bins --locked --force --root $NARGO_HOME
+    RUSTFLAGS="-C target-cpu=native" ensure cargo install --path ./crates/nargo_cli --bins --locked --force --root $NARGO_HOME
 
   fi
 


### PR DESCRIPTION
# Related issue(s)

Related to https://github.com/noir-lang/build-nargo/issues/19#issuecomment-1491320286

# Description

## Summary of changes

The `nargo` cli binary now lives in the `nargo_cli` crate so I've updated the path to point at that crate when installing.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
