### PR TITLE
chore(ci): add CI job for building nargo from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: nargo --version
 
   install-source:
-    name: Noir from Source ${{matrix.toolchain}} (CLI) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
+    name: Noir ${{matrix.version}} (from source) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
     runs-on: ${{matrix.os}}-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ matrix.version }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ matrix.version }}
 
       - name: Install Barretenberg dependencies
         if: matrix.os == 'ubuntu'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        toolchain: [stable, nightly, 0.1.0, 0.1.1, 0.2.0, 0.3.0]
+        toolchain: [stable, nightly, 0.1.0, 0.1.1, 0.2.0, 0.3.0, 0.4.1]
     timeout-minutes: 45
     steps:
       - name: Parse toolchain
@@ -41,8 +41,35 @@ jobs:
           echo "${HOME}/.nargo/bin" >> $GITHUB_PATH
         env:
           INSTALL_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/install
+          NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/noirup
       - name: Install nargo with noirup
         run: noirup ${{steps.parse.outputs.toolchain}} 
+      - name: Check nargo installation
+        run: nargo --version
+
+  install-source:
+    name: Noir from Source ${{matrix.toolchain}} (CLI) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos]
+        # Installing from source can technically target any commit.
+        # However, we only guarantee that noirup will build release commits.
+        version: [0.1.0, 0.1.1, 0.2.0, 0.3.0, 0.4.1]
+    timeout-minutes: 45
+    steps:
+      - name: Install noirup
+        run: |
+          curl -L $INSTALL_URL | bash
+          echo "${HOME}/.nargo/bin" >> $GITHUB_PATH
+        env:
+          INSTALL_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/install
+          NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/noirup
+      - name: Install nargo from source with noirup
+        run: noirup $toolchain
+        env:
+          toolchain: -b tags/v${{matrix.version}}
       - name: Check nargo installation
         run: nargo --version
 
@@ -53,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        toolchain: [stable, nightly, 0.1.0, 0.1.1, 0.2.0, 0.3.0]
+        toolchain: [stable, nightly, 0.1.0, 0.1.1, 0.2.0, 0.3.0, 0.4.1]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,15 @@ jobs:
         env:
           INSTALL_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/install
           NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/noirup
+      
+      - name: Install Barretenberg dependencies
+        if: matrix.os == 'ubuntu'
+        run: sudo apt update && sudo apt install clang lld cmake libomp-dev
+      
+      - name: Install Barretenberg dependencies
+        if: matrix.os == 'macos'
+        run: brew install cmake llvm libomp
+      
       - name: Install nargo from source with noirup
         run: noirup $toolchain
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,16 @@ jobs:
           INSTALL_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/install
           NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/noirup
       
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.nargo/**/target/
+          key: ${{ runner.os }}-cargo-${{ matrix.version }}-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install Barretenberg dependencies
         if: matrix.os == 'ubuntu'
         run: sudo apt update && sudo apt install clang lld cmake libomp-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            ~/.nargo/**/target/
           key: ${{ runner.os }}-cargo-${{ matrix.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Barretenberg dependencies

--- a/install
+++ b/install
@@ -6,13 +6,13 @@ echo Installing noirup...
 NARGO_HOME=${NARGO_HOME-"$HOME/.nargo"}
 NARGO_BIN_DIR="$NARGO_HOME/bin"
 
-BIN_URL="https://github.com/noir-lang/noirup/releases/latest/download/noirup"
-BIN_PATH="$NARGO_BIN_DIR/noirup"
+NOIRUP_BIN_URL=${NOIRUP_BIN_URL-"https://github.com/noir-lang/noirup/releases/latest/download/noirup"}
+NOIRUP_BIN_PATH="$NARGO_BIN_DIR/noirup"
 
 # Create the .nargo bin directory and noirup binary if it doesn't exist.
 mkdir -p $NARGO_BIN_DIR
-curl -# -L $BIN_URL -o $BIN_PATH
-chmod +x $BIN_PATH
+curl -# -L $NOIRUP_BIN_URL -o $NOIRUP_BIN_PATH
+chmod +x $NOIRUP_BIN_PATH
 
 # Store the correct profile file (i.e. .profile for bash or .zshrc for ZSH).
 case $SHELL in


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

We're currently only testing that we can install nargo through noirup as prebuild binaries. One very useful workflow with `noirup` is using it to quickly switch between versions while building from source.

This PR adds a CI job to test that we can compile the release commits from source.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
