### PR TITLE
fix(ci): Checkout the project at release tag to find files to upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ jobs:
     if: ${{ needs.release-please.outputs.tag-name }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.release-please.outputs.tag-name }}
+
       - name: Upload files to release
         uses: svenstaro/upload-release-action@v2
         with:
@@ -38,4 +43,3 @@ jobs:
           file_glob: true
           overwrite: true
           tag: ${{ needs.release-please.outputs.tag-name }}
-


### PR DESCRIPTION
# Related issue(s)

Resolves (link to issue)

# Description

## Summary of changes

I noticed that the CI failed because it couldn't locate any files to upload. This happens because the project is not checked out in the job.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
