### PR TITLE
chore(ci): Use PR repo name to fetch scripts if available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [master]
   pull_request:
-  schedule: 
-   - cron: "40 2 * * *"  # Run 40 mins after nightly noir release (which happens at 2 AM UTC)
+  schedule:
+    - cron: "40 2 * * *" # Run 40 mins after nightly noir release (which happens at 2 AM UTC)
 
 permissions:
   contents: read
@@ -34,16 +34,16 @@ jobs:
           fi
         env:
           toolchain: ${{matrix.toolchain}}
-      
+
       - name: Install noirup
         run: |
           curl -L $INSTALL_URL | bash
           echo "${HOME}/.nargo/bin" >> $GITHUB_PATH
         env:
-          INSTALL_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/install
-          NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/noirup
+          INSTALL_URL: https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name || github.repository }}/${{ github.head_ref || github.ref_name }}/install
+          NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name || github.repository }}/${{ github.head_ref || github.ref_name }}/noirup
       - name: Install nargo with noirup
-        run: noirup ${{steps.parse.outputs.toolchain}} 
+        run: noirup ${{steps.parse.outputs.toolchain}}
       - name: Check nargo installation
         run: nargo --version
 
@@ -64,9 +64,9 @@ jobs:
           curl -L $INSTALL_URL | bash
           echo "${HOME}/.nargo/bin" >> $GITHUB_PATH
         env:
-          INSTALL_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/install
-          NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}/noirup
-      
+          INSTALL_URL: https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name || github.repository }}/${{ github.head_ref || github.ref_name }}/install
+          NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name || github.repository }}/${{ github.head_ref || github.ref_name }}/noirup
+
       - uses: actions/cache@v3
         with:
           path: |
@@ -79,11 +79,11 @@ jobs:
       - name: Install Barretenberg dependencies
         if: matrix.os == 'ubuntu'
         run: sudo apt update && sudo apt install clang lld cmake libomp-dev
-      
+
       - name: Install Barretenberg dependencies
         if: matrix.os == 'macos'
         run: brew install cmake llvm libomp
-      
+
       - name: Install nargo from source with noirup
         run: noirup $toolchain
         env:
@@ -116,4 +116,3 @@ jobs:
       - run: nargo test
         if: matrix.toolchain != '0.1.0'
         working-directory: ./project
-      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+env:
+  REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+  REF: ${{ github.head_ref || github.ref_name }}
+
 jobs:
   install:
     name: Noir ${{matrix.toolchain}} (CLI) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
@@ -40,8 +44,8 @@ jobs:
           curl -L $INSTALL_URL | bash
           echo "${HOME}/.nargo/bin" >> $GITHUB_PATH
         env:
-          INSTALL_URL: https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name || github.repository }}/${{ github.head_ref || github.ref_name }}/install
-          NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name || github.repository }}/${{ github.head_ref || github.ref_name }}/noirup
+          INSTALL_URL: https://raw.githubusercontent.com/${{ env.REPO }}/${{ env.REF }}/install
+          NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ env.REPO }}/${{ env.REF }}/noirup
       - name: Install nargo with noirup
         run: noirup ${{steps.parse.outputs.toolchain}}
       - name: Check nargo installation
@@ -64,8 +68,8 @@ jobs:
           curl -L $INSTALL_URL | bash
           echo "${HOME}/.nargo/bin" >> $GITHUB_PATH
         env:
-          INSTALL_URL: https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name || github.repository }}/${{ github.head_ref || github.ref_name }}/install
-          NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name || github.repository }}/${{ github.head_ref || github.ref_name }}/noirup
+          INSTALL_URL: https://raw.githubusercontent.com/${{ env.REPO }}/${{ env.REF }}/install
+          NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ env.REPO }}/${{ env.REF }}/noirup
 
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

This fixes the workflow so it can run against PRs from forks. It tries to read the repo name from a PR before falling back to `github.repository`.

Since we are reading these files from a fork, we should enable "approval for all outside contributions" in the repo settings.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
