### PR TITLE
feat(flags): add support for feature flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,22 @@ jobs:
       - run: nargo new project
       - run: nargo check
         working-directory: ./project
-      - run: nargo compile test-circuit
+      - run: |
+          if [[ "${{ matrix.toolchain }}" == "stable" || "${{ matrix.toolchain }}" == "nightly" ]]; then
+            nargo compile
+          else
+            minor=$(echo "${{ matrix.toolchain }}" | cut -d '.' -f 2)
+
+            # The version in which the compile syntax changed
+            if [ "$minor" -lt 10 ]; then
+              nargo compile test-circuit
+            else
+              nargo compile
+            fi
+          fi
+        name: nargo compile
         working-directory: ./project
+        shell: bash
       - run: nargo test
         if: matrix.toolchain != '0.1.0'
         working-directory: ./project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,17 +116,17 @@ jobs:
       - run: nargo check
         working-directory: ./project
       - run: |
-          if [[ "${{ matrix.toolchain }}" == "stable" || "${{ matrix.toolchain }}" == "nightly" ]]; then
-            nargo compile
-          else
-            minor=$(echo "${{ matrix.toolchain }}" | cut -d '.' -f 2)
+          # Extract the minor version number from the version output
+          version=$(nargo --version)
+          version="${version#* }"
+          version="${version%% (*}"
+          minor=$(echo $version | cut -d '.' -f 2)
 
-            # The version in which the compile syntax changed
-            if [ "$minor" -lt 10 ]; then
-              nargo compile test-circuit
-            else
-              nargo compile
-            fi
+          # The version in which the compile syntax changed
+          if [ "$minor" -lt 10 ]; then
+            nargo compile test-circuit
+          else
+            nargo compile
           fi
         name: nargo compile
         working-directory: ./project

--- a/noirup
+++ b/noirup
@@ -16,7 +16,7 @@ main() {
       -r|--repo)        shift; NOIRUP_REPO=$1;;
       -b|--branch)      shift; NOIRUP_BRANCH=$1;;
       -v|--version)     shift; NOIRUP_VERSION=$1;;
-      -f|--features)     shift; NOIRUP_FEATURES=$1;;
+      -f|--features)    shift; NOIRUP_FEATURES=$1;;
       -p|--path)        shift; NOIRUP_LOCAL_REPO=$1;;
       -P|--pr)          shift; NOIRUP_PR=$1;;
       -C|--commit)      shift; NOIRUP_COMMIT=$1;;
@@ -29,7 +29,15 @@ main() {
     esac; shift
   done
 
-  FEATURES=${NOIRUP_FEATURES:-"default"}
+  # Input string is a space delimited list of features 
+  # Build a string of feature flags to pass to cargo
+  FEATURES=""
+  if [ -n "$NOIRUP_FEATURES" ]; then
+    # "aztec bn254" -> "--features aztec --features bn254"
+    for feature in $NOIRUP_FEATURES; do
+        FEATURES+="--features $feature "
+    done
+  fi
 
   if [ -n "$NOIRUP_PR" ]; then
     if [ -z "$NOIRUP_BRANCH" ]; then
@@ -51,7 +59,7 @@ main() {
     # Enter local repo and build
     say "installing from $NOIRUP_LOCAL_REPO"
     cd $NOIRUP_LOCAL_REPO
-    RUSTFLAGS="-C target-cpu=native" ensure cargo build --release --features $FEATURES # need 4 speed
+    RUSTFLAGS="-C target-cpu=native" ensure cargo build --release --no-default-features $FEATURES # need 4 speed
 
     # Remove prior installations if they exist
     rm -f "$NARGO_BIN_DIR/nargo"
@@ -61,6 +69,10 @@ main() {
 
     say "done"
     exit 0
+  fi
+
+  if [ -n "${NOIRUP_FEATURES}" ]; then
+      echo "Warning: [-f | --features] flag has no effect when installing a prebuilt binary"
   fi
 
   NOIRUP_REPO=${NOIRUP_REPO-noir-lang/noir}
@@ -149,7 +161,7 @@ main() {
       ensure git checkout ${NOIRUP_COMMIT}
     fi
 
-    RUSTFLAGS="-C target-cpu=native" ensure cargo build --release --features $FEATURES
+    RUSTFLAGS="-C target-cpu=native" ensure cargo build --release --no-default-features $FEATURES
 
     # Remove prior installations if they exist
     rm -f "$NARGO_BIN_DIR/nargo"
@@ -180,7 +192,7 @@ OPTIONS:
     -C, --commit    Install a specific commit
     -r, --repo      Install from a remote GitHub repo (uses default branch if no other options are set)
     -p, --path      Install a local repository
-    -f, --features  Activates feature flags when building from source
+    -f, --features  Activates feature flags when building from source: "feature1 feature2"
 EOF
 }
 

--- a/noirup
+++ b/noirup
@@ -59,7 +59,7 @@ main() {
     # Enter local repo and build
     say "installing from $NOIRUP_LOCAL_REPO"
     cd $NOIRUP_LOCAL_REPO
-    RUSTFLAGS="-C target-cpu=native" ensure cargo build --release --no-default-features $FEATURES # need 4 speed
+    RUSTFLAGS="-C target-cpu=native" ensure cargo build --release $FEATURES # need 4 speed
 
     # Remove prior installations if they exist
     rm -f "$NARGO_BIN_DIR/nargo"
@@ -161,7 +161,7 @@ main() {
       ensure git checkout ${NOIRUP_COMMIT}
     fi
 
-    RUSTFLAGS="-C target-cpu=native" ensure cargo build --release --no-default-features $FEATURES
+    RUSTFLAGS="-C target-cpu=native" ensure cargo build --release $FEATURES
 
     # Remove prior installations if they exist
     rm -f "$NARGO_BIN_DIR/nargo"

--- a/noirup
+++ b/noirup
@@ -16,6 +16,7 @@ main() {
       -r|--repo)        shift; NOIRUP_REPO=$1;;
       -b|--branch)      shift; NOIRUP_BRANCH=$1;;
       -v|--version)     shift; NOIRUP_VERSION=$1;;
+      -f|--features)     shift; NOIRUP_FEATURES=$1;;
       -p|--path)        shift; NOIRUP_LOCAL_REPO=$1;;
       -P|--pr)          shift; NOIRUP_PR=$1;;
       -C|--commit)      shift; NOIRUP_COMMIT=$1;;
@@ -27,6 +28,8 @@ main() {
         err "internal error: unknown option "$1"\n";;
     esac; shift
   done
+
+  FEATURES=${NOIRUP_FEATURES:-"default"}
 
   if [ -n "$NOIRUP_PR" ]; then
     if [ -z "$NOIRUP_BRANCH" ]; then
@@ -48,7 +51,7 @@ main() {
     # Enter local repo and build
     say "installing from $NOIRUP_LOCAL_REPO"
     cd $NOIRUP_LOCAL_REPO
-    RUSTFLAGS="-C target-cpu=native" ensure cargo build --release # need 4 speed
+    RUSTFLAGS="-C target-cpu=native" ensure cargo build --release --features $FEATURES # need 4 speed
 
     # Remove prior installations if they exist
     rm -f "$NARGO_BIN_DIR/nargo"
@@ -146,7 +149,7 @@ main() {
       ensure git checkout ${NOIRUP_COMMIT}
     fi
 
-    RUSTFLAGS="-C target-cpu=native" ensure cargo build --release
+    RUSTFLAGS="-C target-cpu=native" ensure cargo build --release --features $FEATURES
 
     # Remove prior installations if they exist
     rm -f "$NARGO_BIN_DIR/nargo"
@@ -177,6 +180,7 @@ OPTIONS:
     -C, --commit    Install a specific commit
     -r, --repo      Install from a remote GitHub repo (uses default branch if no other options are set)
     -p, --path      Install a local repository
+    -f, --features  Activates feature flags when building from source
 EOF
 }
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

Adds support to noirup to install from source or from a git repo with specific feature flags enabled.

Usage:
```bash
The installer for Nargo.
Update or revert to a specific Nargo version with ease.
USAGE:
    noirup <OPTIONS>
OPTIONS:
    -h, --help      Print help information
    -v, --version   Install a specific version
    -b, --branch    Install a specific branch
    -P, --pr        Install a specific Pull Request
    -C, --commit    Install a specific commit
    -r, --repo      Install from a remote GitHub repo (uses default branch if no other options are set)
    -p, --path      Install a local repository
    -f, --features  Activates feature flags when building from source
```

Example: 
If installing from a local repo with the aztec feature flag enabled:
```bash
noirup -p . -f aztec
```

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
