### PR TITLE
feat: Install noir-profiler and noir-inspector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,8 @@ jobs:
           version_gte() {
             [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
           }
-
-          if version_gte "${{matrix.version}}" "$MIN_VERSION"; then
+          echo ${{matrix.version}}
+          if version_gte ${{matrix.version}} "$MIN_VERSION"; then
             noir-profiler --version
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,6 @@ jobs:
         run: noirup ${{steps.parse.outputs.toolchain}}
       - name: Check nargo installation
         run: nargo --version
-      - name: Check noir-profiler installation
-        run: noir-profiler --version
 
   install-source:
     name: Noir ${{matrix.version}} (from source) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
@@ -119,7 +117,9 @@ jobs:
       - name: Check nargo installation
         run: nargo --version
       - name: Check noir-profiler installation
-        run: noir-profiler --version
+        run: |
+          echo ${{matrix.version}}
+          noir-profiler --version
 
   install-action:
     name: Noir ${{matrix.toolchain}} (GH action) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,6 @@ jobs:
         run: nargo --version
       - name: Check noir-profiler installation
         run: |
-          # Minimum version which began releasing binaries for the `noir-profiler`
-          # Account for the extra `v` that prefixes "${{matrix.version}}"
           MIN_VERSION="v1.0.0-beta.3"
 
           version_gte() {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
         run: nargo --version
       - name: Check noir-profiler installation
         run: |
+          # Fetch the version from `nargo` as to also check the `stable` and `nightly` toolchains
           VERSION=$(nargo --version | awk -F' = ' '/nargo version/ {print $2}')
           MIN_VERSION="1.0.0-beta.3"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,6 @@ jobs:
         run: nargo --version
       - name: Check noir-profiler installation
         run: |
-          # This check ensures compatibility with older versions of Noir
           if [ -f "${HOME}/.nargo/bin/noir-profiler" ]; then
             noir-profiler --version
           fi
@@ -124,7 +123,6 @@ jobs:
         run: nargo --version
       - name: Check noir-profiler installation
         run: |
-          # This check ensures compatibility with older versions of Noir
           if [ -f "${HOME}/.nargo/bin/noir-profiler" ]; then
             noir-profiler --version
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
         run: noirup ${{steps.parse.outputs.toolchain}}
       - name: Check nargo installation
         run: nargo --version
+      - name: Check noir-profiler installation
+        run: noir-profiler --version
 
   install-source:
     name: Noir ${{matrix.version}} (from source) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
@@ -116,6 +118,8 @@ jobs:
           toolchain: -b tags/${{matrix.version}}
       - name: Check nargo installation
         run: nargo --version
+      - name: Check noir-profiler installation
+        run: noir-profiler --version
 
   install-action:
     name: Noir ${{matrix.toolchain}} (GH action) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,11 @@ jobs:
       - name: Check nargo installation
         run: nargo --version
       - name: Check noir-profiler installation
-        # This check ensures compatibility with older versions of Noir
-        if: fileExists('${HOME}/.nargo/bin/noir-profiler')
-        run: noir-profiler --version
+        run: |
+          # This check ensures compatibility with older versions of Noir
+          if [ -f "${HOME}/.nargo/bin/noir-profiler" ]; then
+            noir-profiler --version
+          fi
 
   install-source:
     name: Noir ${{matrix.version}} (from source) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
@@ -121,9 +123,11 @@ jobs:
       - name: Check nargo installation
         run: nargo --version
       - name: Check noir-profiler installation
-        # This check ensures compatibility with older versions of Noir
-        if: fileExists('${HOME}/.nargo/bin/noir-profiler')
-        run: noir-profiler --version
+        run: |
+          # This check ensures compatibility with older versions of Noir
+          if [ -f "${HOME}/.nargo/bin/noir-profiler" ]; then
+            noir-profiler --version
+          fi
 
   install-action:
     name: Noir ${{matrix.toolchain}} (GH action) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
       - name: Check noir-profiler installation
         run: |
           VERSION=$(nargo --version | awk -F' = ' '/nargo version/ {print $2}')
-          # Minimum version which began releasing binaries for the `noir-profiler`
           MIN_VERSION="1.0.0-beta.3"
 
           version_gte() {
@@ -179,7 +178,6 @@ jobs:
         working-directory: ./project
         run: |
           VERSION=$(nargo --version | awk -F' = ' '/nargo version/ {print $2}')
-          # Minimum version which began releasing binaries for the `noir-profiler`.
           MIN_VERSION="1.0.0-beta.3"
 
           version_gte() {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,19 @@ jobs:
         run: noirup ${{steps.parse.outputs.toolchain}}
       - name: Check nargo installation
         run: nargo --version
+      - name: Check noir-inspector installation
+        run: |
+          # Fetch the version from `nargo` as to also check the `stable` and `nightly` toolchains
+          VERSION=$(nargo --version | awk -F' = ' '/nargo version/ {print $2}')
+          MIN_VERSION="1.0.0-beta.3"
+
+          version_gte() {
+            [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+          }
+
+          if version_gte "$VERSION" "$MIN_VERSION"; then
+            noir-inspector --version
+          fi
       - name: Check noir-profiler installation
         run: |
           # Fetch the version from `nargo` as to also check the `stable` and `nightly` toolchains
@@ -129,6 +142,19 @@ jobs:
           toolchain: -b tags/${{matrix.version}}
       - name: Check nargo installation
         run: nargo --version
+      - name: Check noir-inspector installation
+        run: |
+          # Fetch the version from `nargo` as to also check the `stable` and `nightly` toolchains
+          VERSION=$(nargo --version | awk -F' = ' '/nargo version/ {print $2}')
+          MIN_VERSION="1.0.0-beta.3"
+
+          version_gte() {
+            [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+          }
+
+          if version_gte "$VERSION" "$MIN_VERSION"; then
+            noir-inspector --version
+          fi
       - name: Check noir-profiler installation
         run: |
           # Minimum version which began releasing binaries for the `noir-profiler`
@@ -177,6 +203,19 @@ jobs:
         working-directory: ./project
       - run: nargo test
         working-directory: ./project
+      - name: Check noir-inspector installation
+        run: |
+          # Fetch the version from `nargo` as to also check the `stable` and `nightly` toolchains
+          VERSION=$(nargo --version | awk -F' = ' '/nargo version/ {print $2}')
+          MIN_VERSION="1.0.0-beta.3"
+
+          version_gte() {
+            [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+          }
+
+          if version_gte "$VERSION" "$MIN_VERSION"; then
+            noir-inspector --version
+          fi
       - name: Check noir-profiler installation
         working-directory: ./project
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,9 @@ jobs:
         run: nargo --version
       - name: Check noir-profiler installation
         run: |
+          # Fetch the version from `nargo` as to also check the `stable` and `nightly` toolchains
           VERSION=$(nargo --version | awk -F' = ' '/nargo version/ {print $2}')
-          # Minimum version which began releasing binaries for the `noir-profiler`.
+          # Minimum version which began releasing binaries for the `noir-profiler`
           MIN_VERSION="1.0.0-beta.3"
 
           version_gte() {
@@ -131,13 +132,14 @@ jobs:
         run: nargo --version
       - name: Check noir-profiler installation
         run: |
-          # Minimum version which began releasing binaries for the `noir-profiler`.
-          MIN_VERSION="1.0.0-beta.3"
+          # Minimum version which began releasing binaries for the `noir-profiler`
+          # Account for the extra `v` that prefixes "${{matrix.version}}"
+          MIN_VERSION="v1.0.0-beta.3"
 
           version_gte() {
             [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
           }
-          echo ${{matrix.version}}
+
           if version_gte ${{matrix.version}} "$MIN_VERSION"; then
             noir-profiler --version
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,10 @@ jobs:
         run: noirup ${{steps.parse.outputs.toolchain}}
       - name: Check nargo installation
         run: nargo --version
+      - name: Check noir-profiler installation
+        # This check ensures compatibility with older versions of Noir
+        if: fileExists('${HOME}/.nargo/bin/noir-profiler')
+        run: noir-profiler --version
 
   install-source:
     name: Noir ${{matrix.version}} (from source) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
@@ -117,9 +121,9 @@ jobs:
       - name: Check nargo installation
         run: nargo --version
       - name: Check noir-profiler installation
-        run: |
-          echo ${{matrix.version}}
-          noir-profiler --version
+        # This check ensures compatibility with older versions of Noir
+        if: fileExists('${HOME}/.nargo/bin/noir-profiler')
+        run: noir-profiler --version
 
   install-action:
     name: Noir ${{matrix.toolchain}} (GH action) on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,6 @@ jobs:
         run: nargo --version
       - name: Check noir-profiler installation
         run: |
-          # Fetch the version from `nargo` as to also check the `stable` and `nightly` toolchains
           VERSION=$(nargo --version | awk -F' = ' '/nargo version/ {print $2}')
           # Minimum version which began releasing binaries for the `noir-profiler`
           MIN_VERSION="1.0.0-beta.3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,15 @@ jobs:
         run: nargo --version
       - name: Check noir-profiler installation
         run: |
-          if [ -f "${HOME}/.nargo/bin/noir-profiler" ]; then
+          VERSION=$(nargo --version | awk -F' = ' '/nargo version/ {print $2}')
+          # Minimum version which began releasing binaries for the `noir-profiler`.
+          MIN_VERSION="1.0.0-beta.3"
+
+          version_gte() {
+            [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+          }
+
+          if version_gte "$VERSION" "$MIN_VERSION"; then
             noir-profiler --version
           fi
 
@@ -123,7 +131,14 @@ jobs:
         run: nargo --version
       - name: Check noir-profiler installation
         run: |
-          if [ -f "${HOME}/.nargo/bin/noir-profiler" ]; then
+          # Minimum version which began releasing binaries for the `noir-profiler`.
+          MIN_VERSION="1.0.0-beta.3"
+
+          version_gte() {
+            [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+          }
+
+          if version_gte "${{matrix.version}}" "$MIN_VERSION"; then
             noir-profiler --version
           fi
 
@@ -161,3 +176,18 @@ jobs:
         working-directory: ./project
       - run: nargo test
         working-directory: ./project
+      - name: Check noir-profiler installation
+        working-directory: ./project
+        run: |
+          VERSION=$(nargo --version | awk -F' = ' '/nargo version/ {print $2}')
+          # Minimum version which began releasing binaries for the `noir-profiler`.
+          MIN_VERSION="1.0.0-beta.3"
+
+          version_gte() {
+            [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+          }
+
+          if version_gte "$VERSION" "$MIN_VERSION"; then
+            noir-profiler --version
+            noir-profiler opcodes -a ./target/project.json -o ./target
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ jobs:
         run: nargo --version
       - name: Check noir-profiler installation
         run: |
+          # Minimum version which began releasing binaries for the `noir-profiler`
+          # Account for the extra `v` that prefixes "${{matrix.version}}"
           MIN_VERSION="v1.0.0-beta.3"
 
           version_gte() {

--- a/noirup
+++ b/noirup
@@ -4,7 +4,7 @@ set -e
 NARGO_HOME=${NARGO_HOME-"$HOME/.nargo"}
 NARGO_BIN_DIR="$NARGO_HOME/bin"
 
-BINARIES=("nargo" "noir-profiler")
+BINARIES=("nargo" "noir-profiler", "noir-inspector")
 
 main() {
   need_cmd git

--- a/noirup
+++ b/noirup
@@ -4,7 +4,7 @@ set -e
 NARGO_HOME=${NARGO_HOME-"$HOME/.nargo"}
 NARGO_BIN_DIR="$NARGO_HOME/bin"
 
-BINARIES=("nargo" "noir-profiler", "noir-inspector")
+BINARIES=("nargo" "noir-profiler" "noir-inspector")
 
 main() {
   need_cmd git

--- a/noirup
+++ b/noirup
@@ -142,7 +142,7 @@ main() {
     # Legacy naming uses the `nargo-` for when noir-lang/noir used to only release a single nargo binary 
     # Use the legacy naming if `noir-` does not exist
     # Force curl to follow redirects with `-L`
-    if ! curl -v -L --head --fail --silent "$BIN_TARBALL_URL" >/dev/null 2>&1; then
+    if ! curl -L --head --fail --silent "$BIN_TARBALL_URL" >/dev/null 2>&1; then
         echo "got here"
         BIN_TARBALL_URL="${RELEASE_URL}/nargo-${ARCHITECTURE}-${PLATFORM}.tar.gz"
     fi

--- a/noirup
+++ b/noirup
@@ -141,7 +141,8 @@ main() {
     
     # Legacy naming uses the `nargo-` for when noir-lang/noir used to only release a single nargo binary 
     # Use the legacy naming if `noir-` does not exist
-    if ! curl --head --fail "$BIN_TARBALL_URL" >/dev/null 2>&1; then
+    # Force curl to follow redirects with `-L`
+    if ! curl --head --fail --silent -L "$BIN_TARBALL_URL" >/dev/null 2>&1; then
         BIN_TARBALL_URL="${RELEASE_URL}/nargo-${ARCHITECTURE}-${PLATFORM}.tar.gz"
     fi
 

--- a/noirup
+++ b/noirup
@@ -63,9 +63,11 @@ main() {
 
     # Remove prior installations if they exist
     rm -f "$NARGO_BIN_DIR/nargo"
+    rm -f "$NARGO_BIN_DIR/noir-profiler"
 
-    # Move the binary into the `nargo/bin` directory
+    # Move binaries into the `.nargo/bin` directory
     ensure mv "$PWD/target/release/nargo" "$NARGO_BIN_DIR/nargo"
+    ensure mv "$PWD/target/release/noir-profiler" "$NARGO_BIN_DIR/noir-profiler"
 
     say "done"
     exit 0
@@ -121,14 +123,14 @@ main() {
         NOIRUP_TAG="${NOIRUP_VERSION}"
       fi
 
-      say "installing nargo (version ${NOIRUP_VERSION} with tag ${NOIRUP_TAG})"
+      say "installing Noir binaries (version ${NOIRUP_VERSION} with tag ${NOIRUP_TAG})"
 
       RELEASE_URL="https://github.com/${NOIRUP_REPO}/releases/download/${NOIRUP_TAG}"
     fi
-    BIN_TARBALL_URL="${RELEASE_URL}/nargo-${ARCHITECTURE}-${PLATFORM}.tar.gz"
+    BIN_TARBALL_URL="${RELEASE_URL}/noir-${ARCHITECTURE}-${PLATFORM}.tar.gz"
 
     # Download the binaries tarball and unpack it into the .nargo bin directory.
-    say "downloading latest nargo to '$NARGO_BIN_DIR'"
+    say "downloading latest Noir binaries to '$NARGO_BIN_DIR'"
     ensure curl -# -L $BIN_TARBALL_URL | tar -xzC $NARGO_BIN_DIR
 
     # Prior to v0.3.0, Nargo and the std lib were distributed separated.
@@ -165,10 +167,11 @@ main() {
 
     # Remove prior installations if they exist
     rm -f "$NARGO_BIN_DIR/nargo"
+    rm -f "$NARGO_BIN_DIR/noir-profiler"
 
-    # Move the binary into the `nargo/bin` directory
+    # Move binaries into the `.nargo/bin` directory
     ensure mv "$PWD/target/release/nargo" "$NARGO_BIN_DIR/nargo"
-
+    ensure mv "$PWD/target/release/noir-profiler" "$NARGO_BIN_DIR/noir-profiler"
   fi
 
   if [[ $(which nargo) =~ "cargo" ]]; then

--- a/noirup
+++ b/noirup
@@ -142,7 +142,8 @@ main() {
     # Legacy naming uses the `nargo-` for when noir-lang/noir used to only release a single nargo binary 
     # Use the legacy naming if `noir-` does not exist
     # Force curl to follow redirects with `-L`
-    if ! curl --head --fail --silent -L "$BIN_TARBALL_URL" >/dev/null 2>&1; then
+    if ! curl -v -L --head --fail --silent "$BIN_TARBALL_URL" >/dev/null 2>&1; then
+        echo "got here"
         BIN_TARBALL_URL="${RELEASE_URL}/nargo-${ARCHITECTURE}-${PLATFORM}.tar.gz"
     fi
 

--- a/noirup
+++ b/noirup
@@ -127,7 +127,14 @@ main() {
 
       RELEASE_URL="https://github.com/${NOIRUP_REPO}/releases/download/${NOIRUP_TAG}"
     fi
+    # Current name for the binary tarball created by Noir.   
     BIN_TARBALL_URL="${RELEASE_URL}/noir-${ARCHITECTURE}-${PLATFORM}.tar.gz"
+    
+    # Legacy naming uses the `nargo-` for when noir-lang/noir used to only release a single nargo binary 
+    # Use the legacy naming if `noir-` does not exist
+    if ! curl --head --fail "$BIN_TARBALL_URL"; then
+        BIN_TARBALL_URL="${RELEASE_URL}/nargo-${ARCHITECTURE}-${PLATFORM}.tar.gz"
+    fi
 
     # Download the binaries tarball and unpack it into the .nargo bin directory.
     say "downloading latest Noir binaries to '$NARGO_BIN_DIR'"

--- a/noirup
+++ b/noirup
@@ -186,6 +186,7 @@ USAGE:
     noirup <OPTIONS>
 OPTIONS:
     -h, --help      Print help information
+    -n, --nightly   Install the nightly version
     -v, --version   Install a specific version
     -b, --branch    Install a specific branch
     -P, --pr        Install a specific Pull Request

--- a/noirup
+++ b/noirup
@@ -132,7 +132,7 @@ main() {
     
     # Legacy naming uses the `nargo-` for when noir-lang/noir used to only release a single nargo binary 
     # Use the legacy naming if `noir-` does not exist
-    if ! curl --head --fail "$BIN_TARBALL_URL"; then
+    if ! curl --head --fail "$BIN_TARBALL_URL" >/dev/null 2>&1; then
         BIN_TARBALL_URL="${RELEASE_URL}/nargo-${ARCHITECTURE}-${PLATFORM}.tar.gz"
     fi
 

--- a/noirup
+++ b/noirup
@@ -4,6 +4,8 @@ set -e
 NARGO_HOME=${NARGO_HOME-"$HOME/.nargo"}
 NARGO_BIN_DIR="$NARGO_HOME/bin"
 
+BINARIES=("nargo" "noir-profiler")
+
 main() {
   need_cmd git
   need_cmd curl
@@ -62,12 +64,19 @@ main() {
     RUSTFLAGS="-C target-cpu=native" ensure cargo build --release $FEATURES # need 4 speed
 
     # Remove prior installations if they exist
-    rm -f "$NARGO_BIN_DIR/nargo"
-    rm -f "$NARGO_BIN_DIR/noir-profiler"
+    for bin in "${BINARIES[@]}"; do
+      rm -f "$NARGO_BIN_DIR/$bin"
+    done
 
     # Move binaries into the `.nargo/bin` directory
-    ensure mv "$PWD/target/release/nargo" "$NARGO_BIN_DIR/nargo"
-    ensure mv "$PWD/target/release/noir-profiler" "$NARGO_BIN_DIR/noir-profiler"
+    for bin in "${BINARIES[@]}"; do
+        # Move the binary only if it exists.
+        # This ensures compatibility with older versions of Noir, 
+        # which may not include all binaries listed.
+        if [ -f "$PWD/target/release/$bin" ]; then
+            ensure mv "$PWD/target/release/$bin" "$NARGO_BIN_DIR/$bin"
+        fi
+    done
 
     say "done"
     exit 0
@@ -172,13 +181,22 @@ main() {
 
     RUSTFLAGS="-C target-cpu=native" ensure cargo build --release $FEATURES
 
+
     # Remove prior installations if they exist
-    rm -f "$NARGO_BIN_DIR/nargo"
-    rm -f "$NARGO_BIN_DIR/noir-profiler"
+    for bin in "${BINARIES[@]}"; do
+      rm -f "$NARGO_BIN_DIR/$bin"
+    done
 
     # Move binaries into the `.nargo/bin` directory
-    ensure mv "$PWD/target/release/nargo" "$NARGO_BIN_DIR/nargo"
-    ensure mv "$PWD/target/release/noir-profiler" "$NARGO_BIN_DIR/noir-profiler"
+    for bin in "${BINARIES[@]}"; do
+        # Move the binary only if it exists.
+        # This ensures compatibility with older versions of Noir, 
+        # which may not include all binaries listed.
+        if [ -f "$PWD/target/release/$bin" ]; then
+            ensure mv "$PWD/target/release/$bin" "$NARGO_BIN_DIR/$bin"
+        fi
+    done
+  
   fi
 
   if [[ $(which nargo) =~ "cargo" ]]; then


### PR DESCRIPTION
# Description

## Problem\*

Resolves #42 

## Summary\*

This PR simply adds handling for installation of the noir-profiler from source. It uses the new tarball name `noir-{architecture}-{platform}` that contains all Noir binaries after https://github.com/noir-lang/noir/pull/7443.

Adding an additional binary requires a couple changes to be compatible with older versions of Noir. Most notably we do a check against `curl {new binary url}` to determine whether we need to use the old binary url name. 

When compiling from source we switched to checking whether a binary exists before attempting to move it.

## Additional Context

We probably could also rename `.nargo` to `.noir` as we now have Noir binaries that are not contained to just nargo. However, I feel we can do this switch later.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
