### PR TITLE
Add a version command for checking noirup's version installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - "*"
   pull_request:
-    branches: [main]
+    branches:
+      - "*"
   schedule:
-    - cron: "40 2 * * *" # Run 40 mins after nightly noir release (which happens at 2 AM UTC)
+    - cron: "40 2 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
+    branches: [main]
   schedule:
     - cron: "40 2 * * *" # Run 40 mins after nightly noir release (which happens at 2 AM UTC)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
         env:
           INSTALL_URL: https://raw.githubusercontent.com/${{ env.REPO }}/${{ env.REF }}/install
           NOIRUP_BIN_URL: https://raw.githubusercontent.com/${{ env.REPO }}/${{ env.REF }}/noirup
+      - name: Check noirup version
+        run: noirup version
       - name: Install nargo with noirup
         run: noirup ${{steps.parse.outputs.toolchain}}
       - name: Check nargo installation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           ref: ${{ needs.release-please.outputs.tag-name }}
 
+      - name: Update version.txt
+        run: echo "${{ needs.release-please.outputs.tag-name }}" > version.txt
+
       - name: Upload files to release
         uses: svenstaro/upload-release-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
 
 ## Usage
 
+To check which version of noirup you have installed:
+
+```sh
+noirup version
+```
+Example output:
+```sh
+noirup 0.1.4 (7dbe69c 2025-02-20)
+```
+
 To install the **nightly** version:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -124,3 +124,4 @@ All inputs are optional.
 </table>
 
 <br>
+

--- a/noirup
+++ b/noirup
@@ -5,7 +5,19 @@ NARGO_HOME=${NARGO_HOME-"$HOME/.nargo"}
 NARGO_BIN_DIR="$NARGO_HOME/bin"
 
 BINARIES=("nargo" "noir-profiler" "noir-inspector")
-
+if [[ "$1" == "version" ]]; then
+  if [[ -f "$(dirname "$0")/version.txt" ]]; then
+    echo -n "noirup "
+    cat "$(dirname "$0")/version.txt"
+  else
+    # fallback for devs working in git repo
+    TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "unknown")
+    HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+    DATE=$(date +%Y-%m-%d)
+    echo "noirup $TAG ($HASH $DATE)"
+  fi
+  exit 0
+fi
 main() {
   need_cmd git
   need_cmd curl
@@ -210,6 +222,7 @@ main() {
 
   say "done"
 }
+
 
 usage() {
   cat 1>&2 <<EOF


### PR DESCRIPTION
# Description

## Problem\*

Resolves [#50: Add a version command for checking noirup's version installed](https://github.com/cypriansakwa/noirup/issues/50)

## Summary\*

This PR adds a robust `version` command to the noirup Bash script.  
- Running `./noirup version` will now print the version from `version.txt` if present.
- If `version.txt` is missing, the script falls back to displaying the latest git tag, commit hash, and date.
- This approach ensures users and developers always see accurate version information, whether using a release or working from source.

## Additional Context

- The version check occurs before any other script logic for reliability and speed.
- For future releases, update `version.txt` to reflect the latest version.
- Developers working in a git repo without `version.txt` will see dynamic version details.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings (N/A for Bash).